### PR TITLE
Remove repository configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
   },
   "peerDependencies": {
     "isomorphic-fetch": "^3.0.0"
-  },
-  "publishConfig": {
-    "registry": "https://github.com/StatusCakeDev/statuscake-js"
   }
 }


### PR DESCRIPTION
This was causing `npm publish` to try publish the package to the
incorrect registry. This line was originally added by our code
generation tool which has been updated to no longer include it.