### PR TITLE
Update SDK input parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@statuscake/statuscake-js",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@statuscake/statuscake-js",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.1-beta.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statuscake/statuscake-js",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.1-beta.1",
   "description": "StatusCake API client",
   "keywords": [
     "sdk",

--- a/src/apis/ContactGroupsApi.ts
+++ b/src/apis/ContactGroupsApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/apis/LocationsApi.ts
+++ b/src/apis/LocationsApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -44,7 +44,6 @@ export interface ListPagespeedMonitoringLocationsRequest {
 }
 
 export interface ListUptimeMonitoringLocationsRequest {
-  location?: string;
   regionCode?: string;
 }
 
@@ -80,7 +79,6 @@ export interface LocationsApiInterface {
   /**
    * Returns a list of locations detailing server information for uptime monitoring servers. This information can be used to create further checks using the API.
    * @summary Get all uptime monitoring locations
-   * @param {string} [location] Alpha-3 ISO 3166-1 country code
    * @param {string} [regionCode] Server region code
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -163,10 +161,6 @@ export class LocationsApi
     initOverrides?: RequestInit,
   ): Promise<runtime.ApiResponse<MonitoringLocations>> {
     const queryParameters: any = {};
-
-    if (requestParameters.location !== undefined) {
-      queryParameters['location'] = requestParameters.location;
-    }
 
     if (requestParameters.regionCode !== undefined) {
       queryParameters['region_code'] = requestParameters.regionCode;

--- a/src/apis/MaintenanceWindowsApi.ts
+++ b/src/apis/MaintenanceWindowsApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/apis/PagespeedApi.ts
+++ b/src/apis/PagespeedApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -78,6 +78,7 @@ export interface ListPagespeedTestHistoryRequest {
   testId: string;
   limit?: number;
   before?: number;
+  after?: number;
 }
 
 export interface ListPagespeedTestsRequest {
@@ -184,6 +185,7 @@ export interface PagespeedApiInterface {
    * @param {string} testId Pagespeed check ID
    * @param {number} [limit] The number of results to return from the series
    * @param {number} [before] Only results created before this UNIX timestamp will be returned
+   * @param {number} [after] Only results created after this UNIX timestamp will be returned
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PagespeedApiInterface
@@ -545,6 +547,10 @@ export class PagespeedApi
 
     if (requestParameters.before !== undefined) {
       queryParameters['before'] = requestParameters.before;
+    }
+
+    if (requestParameters.after !== undefined) {
+      queryParameters['after'] = requestParameters.after;
     }
 
     const headerParameters: runtime.HTTPHeaders = {};

--- a/src/apis/SslApi.ts
+++ b/src/apis/SslApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/apis/UptimeApi.ts
+++ b/src/apis/UptimeApi.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -104,18 +104,21 @@ export interface ListUptimeTestAlertsRequest {
   testId: string;
   limit?: number;
   before?: number;
+  after?: number;
 }
 
 export interface ListUptimeTestHistoryRequest {
   testId: string;
   limit?: number;
   before?: number;
+  after?: number;
 }
 
 export interface ListUptimeTestPeriodsRequest {
   testId: string;
   limit?: number;
   before?: number;
+  after?: number;
 }
 
 export interface ListUptimeTestsRequest {
@@ -265,6 +268,7 @@ export interface UptimeApiInterface {
    * @param {string} testId Uptime check ID
    * @param {number} [limit] The number of uptime alerts to return per page
    * @param {number} [before] Only alerts triggered before this UNIX timestamp will be returned
+   * @param {number} [after] Only alerts triggered after this UNIX timestamp will be returned
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof UptimeApiInterface
@@ -289,6 +293,7 @@ export interface UptimeApiInterface {
    * @param {string} testId Uptime check ID
    * @param {number} [limit] The number of results to return per page
    * @param {number} [before] Only results created before this UNIX timestamp will be returned
+   * @param {number} [after] Only results created after this UNIX timestamp will be returned
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof UptimeApiInterface
@@ -313,6 +318,7 @@ export interface UptimeApiInterface {
    * @param {string} testId Uptime check ID
    * @param {number} [limit] The number of uptime check periods to return per page
    * @param {number} [before] Only check periods created before this UNIX timestamp will be returned
+   * @param {number} [after] Only check periods created after this UNIX timestamp will be returned
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof UptimeApiInterface
@@ -806,6 +812,10 @@ export class UptimeApi extends runtime.BaseAPI implements UptimeApiInterface {
       queryParameters['before'] = requestParameters.before;
     }
 
+    if (requestParameters.after !== undefined) {
+      queryParameters['after'] = requestParameters.after;
+    }
+
     const headerParameters: runtime.HTTPHeaders = {};
 
     const response = await this.request(
@@ -869,6 +879,10 @@ export class UptimeApi extends runtime.BaseAPI implements UptimeApiInterface {
       queryParameters['before'] = requestParameters.before;
     }
 
+    if (requestParameters.after !== undefined) {
+      queryParameters['after'] = requestParameters.after;
+    }
+
     const headerParameters: runtime.HTTPHeaders = {};
 
     const response = await this.request(
@@ -930,6 +944,10 @@ export class UptimeApi extends runtime.BaseAPI implements UptimeApiInterface {
 
     if (requestParameters.before !== undefined) {
       queryParameters['before'] = requestParameters.before;
+    }
+
+    if (requestParameters.after !== undefined) {
+      queryParameters['after'] = requestParameters.after;
     }
 
     const headerParameters: runtime.HTTPHeaders = {};

--- a/src/models/APIError.ts
+++ b/src/models/APIError.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/APIResponse.ts
+++ b/src/models/APIResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/APIResponseData.ts
+++ b/src/models/APIResponseData.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/ContactGroup.ts
+++ b/src/models/ContactGroup.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/ContactGroupResponse.ts
+++ b/src/models/ContactGroupResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/ContactGroups.ts
+++ b/src/models/ContactGroups.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/Links.ts
+++ b/src/models/Links.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MaintenanceWindow.ts
+++ b/src/models/MaintenanceWindow.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MaintenanceWindowRepeatInterval.ts
+++ b/src/models/MaintenanceWindowRepeatInterval.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MaintenanceWindowResponse.ts
+++ b/src/models/MaintenanceWindowResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MaintenanceWindowState.ts
+++ b/src/models/MaintenanceWindowState.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MaintenanceWindows.ts
+++ b/src/models/MaintenanceWindows.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MonitoringLocation.ts
+++ b/src/models/MonitoringLocation.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MonitoringLocationStatus.ts
+++ b/src/models/MonitoringLocationStatus.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/MonitoringLocations.ts
+++ b/src/models/MonitoringLocations.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTest.ts
+++ b/src/models/PagespeedTest.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestCheckRate.ts
+++ b/src/models/PagespeedTestCheckRate.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestHistory.ts
+++ b/src/models/PagespeedTestHistory.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestHistoryResult.ts
+++ b/src/models/PagespeedTestHistoryResult.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestRegion.ts
+++ b/src/models/PagespeedTestRegion.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestResponse.ts
+++ b/src/models/PagespeedTestResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestStats.ts
+++ b/src/models/PagespeedTestStats.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTestThrottling.ts
+++ b/src/models/PagespeedTestThrottling.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/PagespeedTests.ts
+++ b/src/models/PagespeedTests.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/Pagination.ts
+++ b/src/models/Pagination.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTest.ts
+++ b/src/models/SSLTest.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTestCheckRate.ts
+++ b/src/models/SSLTestCheckRate.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTestFlags.ts
+++ b/src/models/SSLTestFlags.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTestMixedContent.ts
+++ b/src/models/SSLTestMixedContent.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTestResponse.ts
+++ b/src/models/SSLTestResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/SSLTests.ts
+++ b/src/models/SSLTests.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTest.ts
+++ b/src/models/UptimeTest.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestAlert.ts
+++ b/src/models/UptimeTestAlert.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestAlerts.ts
+++ b/src/models/UptimeTestAlerts.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestCheckRate.ts
+++ b/src/models/UptimeTestCheckRate.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestHistory.ts
+++ b/src/models/UptimeTestHistory.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestHistoryResult.ts
+++ b/src/models/UptimeTestHistoryResult.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestOverview.ts
+++ b/src/models/UptimeTestOverview.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestPeriod.ts
+++ b/src/models/UptimeTestPeriod.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestPeriods.ts
+++ b/src/models/UptimeTestPeriods.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestProcessingState.ts
+++ b/src/models/UptimeTestProcessingState.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestResponse.ts
+++ b/src/models/UptimeTestResponse.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestStatus.ts
+++ b/src/models/UptimeTestStatus.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTestType.ts
+++ b/src/models/UptimeTestType.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/models/UptimeTests.ts
+++ b/src/models/UptimeTests.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 


### PR DESCRIPTION
Bump the version of the SDK to accommodate for the following changes:

 - Remove the `location` parameter from the uptime monitoring locations endpoint
 - Add an `after` parameter to restrict the number of resources returned from time series endpoints.