### PR TITLE
Remove unused modules from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ client and execute a request:
 import 'isomorphic-fetch';
 import {
   Configuration,
-  ContactGroupsApi,
-  LocationsApi,
-  MaintenanceWindowsApi,
-  PagespeedApi,
-  SslApi,
   UptimeApi,
 } from '@statuscake/statuscake-js';
 


### PR DESCRIPTION
Some of the modules imported as an example in the README are unused and may confuse the piece as documentation. They have been removed.